### PR TITLE
Delete "no unsafe" claim from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ A zero-allocation no_std-compatible zero-cost way to add color to your Rust term
     * [x] Truecolor support (modern, 48-bit color)
 * [x] Styling (underline, strikethrough, etc)
 
-owo-colors is also more-or-less a drop-in replacement for [colored](https://crates.io/crates/colored), allowing colored to work in a no_std environment. No allocations, unsafe, or dependencies required because embedded systems deserve to be pretty too uwu.
+owo-colors is also more-or-less a drop-in replacement for [colored](https://crates.io/crates/colored), allowing colored to work in a no_std environment. No allocations or dependencies required because embedded systems deserve to be pretty too uwu.
 
 To add to your Cargo.toml:
 ```toml


### PR DESCRIPTION
"No unsafe" is misleading because there is unsafe code unconditionally compiled into the crate.

It looks like this sentence in the readme was written in 408f42a3f1b10f23ca4bfc031ce962750d9faac4 and "no unsafe" was true at that point, but then 48 hours later some unsafe code was added in 8904b5e738aa6b3ddfc60cee9fa4aa6bd213e399 and has been there ever since. It seems like an oversight that the readme was not updated.