### PR TITLE
explicitly mark Color and DynColor sealed

### DIFF
--- a/src/colors.rs
+++ b/src/colors.rs
@@ -23,6 +23,8 @@ macro_rules! colors {
                 )*
             }
 
+            impl crate::private::Sealed for AnsiColors {}
+
             impl crate::DynColor for AnsiColors {
                 fn fmt_ansi_fg(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
                     let color = match self {
@@ -79,6 +81,8 @@ macro_rules! colors {
         $(
             /// A color for use with [`OwoColorize`](crate::OwoColorize)'s `fg` and `bg` methods.
             pub struct $color;
+
+            impl crate::private::Sealed for $color {}
 
             impl crate::Color for $color {
                 const ANSI_FG: &'static str = concat!("\x1b[", stringify!($fg), "m");

--- a/src/colors/css.rs
+++ b/src/colors/css.rs
@@ -20,6 +20,8 @@ macro_rules! css_color_types {
 
         use dynamic::CssColors;
 
+        impl crate::private::Sealed for CssColors {}
+
         impl crate::DynColor for CssColors {
             fn fmt_ansi_fg(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
                 let color = match self {

--- a/src/colors/custom.rs
+++ b/src/colors/custom.rs
@@ -94,6 +94,8 @@ impl<const R: u8, const G: u8, const B: u8> CustomColor<R, G, B> {
     const RAW_ANSI_BG_U8: [u8; 16] = rgb_to_ansi_color(R, G, B, true);
 }
 
+impl<const R: u8, const G: u8, const B: u8> crate::private::Sealed for CustomColor<R, G, B> {}
+
 impl<const R: u8, const G: u8, const B: u8> Color for CustomColor<R, G, B> {
     const ANSI_FG: &'static str = bytes_to_str(&Self::ANSI_FG_U8);
     const ANSI_BG: &'static str = bytes_to_str(&Self::ANSI_BG_U8);

--- a/src/colors/dynamic.rs
+++ b/src/colors/dynamic.rs
@@ -9,6 +9,8 @@ use crate::OwoColorize;
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct Rgb(pub u8, pub u8, pub u8);
 
+impl crate::private::Sealed for Rgb {}
+
 impl DynColor for Rgb {
     fn fmt_ansi_fg(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let Rgb(r, g, b) = self;
@@ -41,6 +43,8 @@ impl DynColor for Rgb {
         self.get_dyncolors_fg()
     }
 }
+
+impl crate::private::Sealed for str {}
 
 impl DynColor for str {
     fn fmt_ansi_fg(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/src/colors/xterm.rs
+++ b/src/colors/xterm.rs
@@ -19,6 +19,8 @@ macro_rules! xterm_colors {
                 )*
             }
 
+            impl crate::private::Sealed for XtermColors {}
+
             impl crate::DynColor for XtermColors {
                 fn fmt_ansi_fg(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
                     let color = match self {
@@ -95,6 +97,8 @@ macro_rules! xterm_colors {
         $(
             #[allow(missing_docs)]
             pub struct $name;
+
+            impl crate::private::Sealed for $name {}
 
             impl crate::Color for $name {
                 const ANSI_FG: &'static str = concat!("\x1b[38;5;", stringify!($xterm_num), "m");

--- a/src/dyn_colors.rs
+++ b/src/dyn_colors.rs
@@ -17,6 +17,8 @@ pub enum DynColors {
     Rgb(u8, u8, u8),
 }
 
+impl crate::private::Sealed for DynColors {}
+
 impl DynColor for DynColors {
     fn fmt_ansi_fg(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -91,9 +91,15 @@ pub(crate) use overrides::OVERRIDE;
 use core::fmt;
 use core::marker::PhantomData;
 
+mod private {
+    // Not actually reachable.
+    #[doc(hidden)]
+    pub trait Sealed {}
+}
+
 /// A trait for describing a type which can be used with [`FgColorDisplay`] or
 /// [`BgColorDisplay`]
-pub trait Color {
+pub trait Color: private::Sealed {
     /// The ANSI format code for setting this color as the foreground
     const ANSI_FG: &'static str;
 
@@ -121,7 +127,7 @@ pub trait Color {
 /// A trait describing a runtime-configurable color which can displayed using [`FgDynColorDisplay`]
 /// or [`BgDynColorDisplay`]. If your color will be known at compile time it
 /// is recommended you avoid this.
-pub trait DynColor {
+pub trait DynColor: private::Sealed {
     /// A function to output a ANSI code to a formatter to set the foreground to this color
     fn fmt_ansi_fg(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result;
     /// A function to output a ANSI code to a formatter to set the background to this color


### PR DESCRIPTION
These were already effectively sealed via the doc(hidden) methods, but we should also mark it so.